### PR TITLE
Disable XDebug to speed up Travis builds

### DIFF
--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -15,6 +15,12 @@ if [ $1 == 'before' ]; then
 		composer global require "phpunit/phpunit=6.2.*"
 	fi
 
+	# Remove Xdebug from PHP runtime for all PHP version except 7.1 to speed up builds.
+	# We need Xdebug enabled in the PHP 7.1 build job as it is used to generate code coverage.
+	if [[ ${TRAVIS_PHP_VERSION} != '7.1' ]]; then
+		phpenv config-rm xdebug.ini
+	fi
+
 fi
 
 if [ $1 == 'after' ]; then


### PR DESCRIPTION
This commit removes Xdebug from PHP runtime on all build jobs except PHP 7.1 to speed up Travis builds. Xdebug is needed in the PHP 7.1 build job because this job is used to generate code coverage.