### PR TITLE
Use WP beta5 when running PHP 7.3 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - 7.3
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
@@ -31,9 +30,13 @@ matrix:
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_PHPCS=1 RUN_E2E=1
   - php: 7.1
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
-  allow_failures:
-  - env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
   - php: 7.3
+    env: WP_VERSION=5.0-beta5 WP_MULTISITE=0
+  allow_failures:
+  - php: 7.1
+    env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
+  - php: 7.3
+    env: WP_VERSION=5.0-beta5 WP_MULTISITE=0
 
 before_script:
   - |

--- a/tests/bin/install.sh
+++ b/tests/bin/install.sh
@@ -24,7 +24,7 @@ download() {
     fi
 }
 
-if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)?(^-) ]]; then
 	WP_TESTS_TAG="tags/$WP_VERSION"
 elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
 	WP_TESTS_TAG="trunk"


### PR DESCRIPTION
To make it easier to test WC running the upcoming PHP 7.3, this commit changes the PHP 7.3 Travis build to run unit tests using WP nightly. This way we won't display WP core warnings related to PHP 7.3 that were already fixed in the upcoming WP version and will be able to see only WC related warnings.