### PR TITLE
Use separate Travis build jobs to run e2e tests and PHPCS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
@@ -27,7 +28,9 @@ matrix:
   - php: 5.2
     dist: precise
   - php: 7.2
-    env: WP_VERSION=latest WP_MULTISITE=0 RUN_PHPCS=1 RUN_E2E=1
+    env: WP_VERSION=latest WP_MULTISITE=0 RUN_PHPCS=1
+  - php: 7.2
+    env: WP_VERSION=latest WP_MULTISITE=0 RUN_E2E=1
   - php: 7.1
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
   - php: 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_script:
     else
       echo "xdebug.ini does not exist"
     fi
-  - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - export PATH="$HOME/.config/composer/vendor/bin:$PATH"
   - bash tests/bin/install.sh woocommerce_test root '' localhost $WP_VERSION
   - bash tests/bin/travis.sh before
 

--- a/tests/bin/phpunit.sh
+++ b/tests/bin/phpunit.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+if [[ ${RUN_PHPCS} == 1 ]] || [[ ${RUN_E2E} == 1 ]]; then
+	exit
+fi
+
 if [[ ${RUN_CODE_COVERAGE} == 1 ]]; then
 	phpdbg -qrr -d memory_limit=-1 $HOME/.composer/vendor/bin/phpunit -c phpunit.xml --coverage-clover=coverage.clover --exclude-group=timeout
 else


### PR DESCRIPTION
This commit creates two new Travis build jobs, one to run the e2e tests and another to run PHPCS. Doing this, instead of running those two checks in the same build job as the PHP 7.2 unit tests, should make the total build time shorter and it should make it easier to see why the build failed.