### PR TITLE
Only install Chrome and Nginx in the build job that uses it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 language: php
 dist: trusty
 
-addons:
-  chrome: stable
-  apt:
-    packages:
-      - nginx
-
 sudo: false
 
 cache:
@@ -40,6 +34,11 @@ matrix:
   - name: "e2e tests"
     php: 7.2
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_E2E=1
+    addons:
+      chrome: stable
+      apt:
+        packages:
+          - nginx
   - name: "Unit tests code coverage"
     php: 7.3
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1


### PR DESCRIPTION
This commit changes Travis configuration to only install Chrome and Nginx in the e2e tests build job, which is the only one that requires those packages. This change should save a little bit of time in the Travis build as before Travis was installing Chrome and Nginx in all the jobs.
