### PR TITLE
Make sure NPM binaries folder is included in the $PATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
 
 before_script:
-  - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - export PATH=`npm bin`:"$HOME/.composer/vendor/bin:$PATH"
   - |
     # Remove Xdebug for a huge performance increase:
     if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then

--- a/tests/bin/install.sh
+++ b/tests/bin/install.sh
@@ -170,6 +170,7 @@ install_e2e_site() {
 		fi
 
 		set -ev
+		npm i -g npm
 		npm install
 		export NODE_CONFIG_DIR="./tests/e2e-tests/config"
 


### PR DESCRIPTION
Doing this to avoid problems in the builds like the one below where the e2e tests are failing because the shell can't find the command cross-env:

"sh: 1: cross-env: not found" (https://travis-ci.org/woocommerce/woocommerce/jobs/529070020#L684)

I'm assuming this error started happening after a change in the Travis environment (maybe a NPM update or something like that) that changed the location of the folder where NPM keeps the binaries of the installed packages.